### PR TITLE
Bump Bevy version to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,13 @@ opt-level = 3
 members = ["./", "tools/ci"]
 
 [dependencies]
-bevy_app = {version = "0.6", default-features = false}
-bevy_ecs = { version = "0.6", default-features = false}
-bevy_math = { version = "0.6", default-features = false}
-bevy_transform = { version = "0.6", default-features = false}
-bevy_core = {version = "0.6", default-features = false}
+bevy_app = {version = "0.7", default-features = false}
+bevy_ecs = { version = "0.7", default-features = false}
+bevy_math = { version = "0.7", default-features = false}
+bevy_transform = { version = "0.7", default-features = false}
+bevy_core = {version = "0.7", default-features = false}
 derive_more = "0.99"
 leafwing_2d_macros = { path = "macros", version = "0.1" }
 
 [dev-dependencies]
-bevy = "0.6"
+bevy = "0.7"


### PR DESCRIPTION
## What was the problem?

Crate was depending on Bevy 0.6, rendering it incompatible with projects using Bevy 0.7.

## How did you fix it?

Bumped Bevy dependency to version 0.7.

